### PR TITLE
showing currency symbols before amount #89

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ yarn-debug.log*
 yarn-error.log*
 
 # local env files
+.env
 .env*.local
 
 # vercel

--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,6 @@ yarn-debug.log*
 yarn-error.log*
 
 # local env files
-.env
 .env*.local
 
 # vercel

--- a/src/app/dashboard/components/expenses/expenses-chart.tsx
+++ b/src/app/dashboard/components/expenses/expenses-chart.tsx
@@ -106,7 +106,7 @@ export default function ExpensesChart() {
             />
 
             <YAxis
-              tickFormatter={(number) => `${number}${currency}`}
+              tickFormatter={(number) => `${currency}${number}`}
               tickCount={6}
             />
             <Tooltip content={<CustomTooltip currency={currency} />} />

--- a/src/app/dashboard/components/expenses/expenses-evolution-chart.tsx
+++ b/src/app/dashboard/components/expenses/expenses-evolution-chart.tsx
@@ -118,7 +118,7 @@ export default function ExpensesEvolutionChart() {
               }}
             />
             <YAxis
-              tickFormatter={(number) => `${number}${currency}`}
+              tickFormatter={(number) => `${currency}${number}`}
               tickCount={6}
             />
             <Tooltip content={<CustomTooltip currency={currency} />} />

--- a/src/app/dashboard/components/incomes/incomes-chart.tsx
+++ b/src/app/dashboard/components/incomes/incomes-chart.tsx
@@ -104,7 +104,7 @@ export default function IncomesChart() {
               }}
             />
             <YAxis
-              tickFormatter={(number) => `${number}${currency}`}
+              tickFormatter={(number) => `${currency}${number}`}
               tickCount={6}
             />
             <Tooltip content={<CustomTooltip currency={currency} />} />

--- a/src/app/dashboard/components/incomes/incomes-evolution-chart.tsx
+++ b/src/app/dashboard/components/incomes/incomes-evolution-chart.tsx
@@ -118,7 +118,7 @@ export default function IncomesEvolutionChart() {
               }}
             />
             <YAxis
-              tickFormatter={(number) => `${number}${currency}`}
+              tickFormatter={(number) => `${currency}${number}`}
               tickCount={6}
             />
             <Tooltip content={<CustomTooltip currency={currency} />} />

--- a/src/app/dashboard/components/total/balance.tsx
+++ b/src/app/dashboard/components/total/balance.tsx
@@ -14,11 +14,12 @@ import {
   CardHeader,
   CardTitle,
 } from "../../../components/ui/card";
+import { useMemo } from "react";
 
 export function Balance() {
   const { transactions, currency } = useContext(AppContext);
 
-  function getBalance() {
+  const balance = useMemo(() => {
     const expenses = getTotalExpenses(transactions);
     const incomes = getTotalIncomes(transactions);
     const special = getInvested(transactions) + getSavings(transactions);
@@ -26,7 +27,7 @@ export function Balance() {
     const balance = incomes - expenses - special + uncategorized;
 
     return roundToTwoDecimal(balance);
-  }
+  }, [transactions]);
 
   return (
     <Card className="pr-14 w-full md:w-1/2">
@@ -45,22 +46,35 @@ export function Balance() {
           Current balance
         </CardDescription>
         <CardTitle className="font-mono tabular-nums text-2xl md:text-3xl">
-          {formatNumberWithTwoDecimals(getBalance())}
-          {currency}
+          {balance < 0 ? (
+            <>
+              <span className="text-red-500">
+                -{currency}
+                {formatNumberWithTwoDecimals(Math.abs(balance))}
+              </span>
+            </>
+          ) : (
+            <>
+              <span className="text-green-500">
+                +{currency}
+                {formatNumberWithTwoDecimals(balance)}
+              </span>
+            </>
+          )}
         </CardTitle>
         <div className="flex flex-col w-fit bg-gray-50 p-2 rounded-md">
           <CardDescription className="flex gap-1">
             Savings:
             <span className="font-mono tabular-nums text-sm flex gap-1">
-              {formatNumberWithTwoDecimals(getSavings(transactions))}
               {currency}
+              {formatNumberWithTwoDecimals(getSavings(transactions))}
             </span>
           </CardDescription>
           <CardDescription className="flex gap-1">
             Invested:
             <span className="font-mono tabular-nums text-sm flex gap-1">
-              {formatNumberWithTwoDecimals(getInvested(transactions))}
               {currency}
+              {formatNumberWithTwoDecimals(getInvested(transactions))}
             </span>
           </CardDescription>
         </div>

--- a/src/app/dashboard/components/total/expenses.tsx
+++ b/src/app/dashboard/components/total/expenses.tsx
@@ -38,8 +38,8 @@ export function Expenses() {
         </CardDescription>
         <CardTitle className="text-red-500 text-lg md:text-xl font-mono tabular-nums">
           {expenses !== 0 && "-"}
-          {formatNumberWithTwoDecimals(expenses)}
           {currency}
+          {formatNumberWithTwoDecimals(expenses)}
         </CardTitle>
       </CardHeader>
     </Card>

--- a/src/app/dashboard/components/total/incomes.tsx
+++ b/src/app/dashboard/components/total/incomes.tsx
@@ -35,8 +35,8 @@ export function Incomes() {
         </CardDescription>
         <CardTitle className="text-green-500 text-lg md:text-xl font-mono tabular-nums">
           {incomes !== 0 && "+"}
-          {formatNumberWithTwoDecimals(incomes)}
           {currency}
+          {formatNumberWithTwoDecimals(incomes)}
         </CardTitle>
       </CardHeader>
     </Card>

--- a/src/app/dashboard/components/total/summary.tsx
+++ b/src/app/dashboard/components/total/summary.tsx
@@ -146,7 +146,7 @@ export default function SummaryChart() {
                 }}
               />
               <YAxis
-                tickFormatter={(number) => `${number}${currency}`}
+                tickFormatter={(number) => `${currency}${number}`}
                 tickCount={6}
               />
               <Legend />

--- a/src/app/dashboard/components/ui/graph-utils.tsx
+++ b/src/app/dashboard/components/ui/graph-utils.tsx
@@ -5,8 +5,8 @@ export function CustomTooltip({ active, payload, label, currency }: any) {
     return (
       <div className="bg-emerald-700 text-white p-4 rounded-md shadow-xl">
         <h4 className="text-lg mb-2">
-          {formatNumberWithTwoDecimals(payload[0].value)}
           {currency}
+          {formatNumberWithTwoDecimals(payload[0].value)}
         </h4>
         <p className="text-sm font-sans">{formatDateToReadable(label)}</p>
       </div>
@@ -20,8 +20,8 @@ export function PieChartTooltip({ active, payload, currency }: any) {
     return (
       <div className="bg-emerald-700 text-white p-4 rounded-md shadow-xl">
         <h4 className="text-lg mb-2">
-          {formatNumberWithTwoDecimals(payload[0].value)}
           {currency}
+          {formatNumberWithTwoDecimals(payload[0].value)}
         </h4>
         <p className="text-sm font-sans">{payload[0].name}</p>
       </div>
@@ -36,13 +36,13 @@ export function SummaryTooltip({ active, payload, label, currency }: any) {
       <div className="bg-emerald-700 text-white p-4 rounded-md shadow-xl">
         <h4 className="text-lg">
           Income:
-          {formatNumberWithTwoDecimals(payload[0].payload.income)}
           {currency}
+          {formatNumberWithTwoDecimals(payload[0].payload.income)}
         </h4>
         <h4 className="text-lg mb-2">
           Expense:
-          {formatNumberWithTwoDecimals(payload[0].payload.expense)}
           {currency}
+          {formatNumberWithTwoDecimals(payload[0].payload.expense)}
         </h4>
         <p className="text-sm font-sans">{formatDateToReadable(label)}</p>
       </div>


### PR DESCRIPTION
# Pull Request Template

## What
This PR is related to issue #89, where I have worked on showing the currency symbols before the total amount

Here is the final version, tacked all the possibilities where the currency symbols are appearing from `pie-chart` to `line-chart` I covered them all

## Before 
![image](https://github.com/user-attachments/assets/ae8ac45c-f8d3-4aba-88a3-9b656868409a)

## After
![image](https://github.com/user-attachments/assets/abd21b42-8aaa-4ae2-bda8-0ca8f0bca3d3)


## How
Most of the changes are simply done via putting the `currency` ticker before the amount, but in balance section I have used the `usememo` hook to perform an optimized calculation between renders to avoid functioncalling each time.

## Additional Notes
I faced a lot of errors while setting up the project but thanks to @manuelalferez readme update which clarifies each and everything.